### PR TITLE
Allow imperilment ask first time

### DIFF
--- a/scripts/imperilment.coffee
+++ b/scripts/imperilment.coffee
@@ -59,7 +59,7 @@ class AllInMessage extends Message
 
 module.exports = (robot) ->
   tooOften = ->
-    lastAsked = robot.brain.get('lastAskedWhoIsIn') || new Date
+    lastAsked = robot.brain.get('lastAskedWhoIsIn') || new Date(0)
     new Date - lastAsked < channelSpamDelay
 
   tooSoon = ->


### PR DESCRIPTION
By using `new Date()` I had accidentally made sure that nobody could pass this test. The first run would fail, then `lastAskedWhoIsIn` was never set and all subsequent runs would fail too.
